### PR TITLE
removed value caching

### DIFF
--- a/lib/motion-config-vars/embed/hashlike_object_configurer.rb
+++ b/lib/motion-config-vars/embed/hashlike_object_configurer.rb
@@ -28,7 +28,7 @@ module MotionConfigVars
   protected
 
     def set key, value
-      @hashlike_object[key] ||= value
+      @hashlike_object[key] = value
     end
 
     def validate_config_name_for_facet_named_is_closure


### PR DESCRIPTION
removed the ||= value setting. this would break a long running simulator session by caching the first version of a key in ENV (since ENV lives the length of the simulator process).
